### PR TITLE
Dont pin exact httpx version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,7 @@ packages = find:
 install_requires =
 	idna < 3
 	web3 >= 5.16
-	httpx == 0.16
+	httpx >= 0.16
 	pydantic >= 1.7
 	mypy >= 0.8
 


### PR DESCRIPTION
Allow httpx versions other than 0.16. Pinning an exact version often makes it impossible for applications that have other dependencies to resolve compatible dependency versions.