### PR TITLE
Add contract ABIs to distribution

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,11 @@ include =
    	zksync_sdk
     zksync_sdk.*
 
+[options.package_data]
+zksync_sdk.contract_abi =
+    IERC20.json
+    ZkSync.json
+
 [tox:tox]
 envlist = py{38,39},mypy
 


### PR DESCRIPTION
The functions in `zksync_abi.contract_utils` are broken without these files being included in the distribution.