### PR TITLE
Fix token amount to decimal string conversion

### DIFF
--- a/zksync_sdk/types/transactions.py
+++ b/zksync_sdk/types/transactions.py
@@ -82,7 +82,7 @@ class Token(BaseModel):
 
         # Creates a string with `self.decimals` numbers after decimal point.
         # Prevents scientific notation (string values like '1E-8').
-        d_str = f"{d}:.{self.decimals}f"
+        d_str = f"{d:.{self.decimals}f}"
 
         # For non-zero integral numbers add the ".0" suffix
         if "." not in d_str:

--- a/zksync_sdk/types/transactions.py
+++ b/zksync_sdk/types/transactions.py
@@ -82,11 +82,8 @@ class Token(BaseModel):
 
         # Creates a string with `self.decimals` numbers after decimal point.
         # Prevents scientific notation (string values like '1E-8').
+        # Prevents integral numbers having no decimal point in the string representation.
         d_str = f"{d:.{self.decimals}f}"
-
-        # For non-zero integral numbers add the ".0" suffix
-        if "." not in d_str:
-            return d_str + ".0"
 
         d_str = d_str.rstrip("0")
         if d_str[-1] == ".":

--- a/zksync_sdk/types/transactions.py
+++ b/zksync_sdk/types/transactions.py
@@ -75,10 +75,23 @@ class Token(BaseModel):
 
     def decimal_str_amount(self, amount: int) -> str:
         d = self.decimal_amount(amount)
-        if d != Decimal(0):
-            return str(d).rstrip("0")
-        else:
-            return str(d)
+
+        # zero is the only exception where we don't add a decimal point
+        if d == 0:
+            return "0"
+
+        # Creates a string with `self.decimals` numbers after decimal point.
+        # Prevents scientific notation (string values like '1E-8').
+        d_str = f"{d}:.{self.decimals}f"
+
+        # For non-zero integral numbers add the ".0" suffix
+        if "." not in d_str:
+            return d_str + ".0"
+
+        d_str = d_str.rstrip("0")
+        if d_str[-1] == ".":
+            return d_str + "0"
+        return d_str
 
 
 class Tokens(BaseModel):


### PR DESCRIPTION
The current implementation has issues that lead to invalid eth signatures.

E.g. `Decimal(20)` was converted to `"2"`, and `Decimal("2.0")` was converted to `"2."`. This PR fixes these issues. 