### PR TITLE
Make `EthereumSignerInterface` sign methods synchronous

### DIFF
--- a/zksync_sdk/ethereum_signer/interface.py
+++ b/zksync_sdk/ethereum_signer/interface.py
@@ -8,11 +8,11 @@ __all__ = ['EthereumSignerInterface']
 class EthereumSignerInterface(ABC):
 
     @abstractmethod
-    async def sign_tx(self, tx: EncodedTx) -> TxEthSignature:
+    def sign_tx(self, tx: EncodedTx) -> TxEthSignature:
         raise NotImplementedError
 
     @abstractmethod
-    async def sign(self, message: bytes) -> TxEthSignature:
+    def sign(self, message: bytes) -> TxEthSignature:
         raise NotImplementedError
 
     @abstractmethod

--- a/zksync_sdk/ethereum_signer/web3.py
+++ b/zksync_sdk/ethereum_signer/web3.py
@@ -11,11 +11,11 @@ class EthereumSignerWeb3(EthereumSignerInterface):
     def __init__(self, account: BaseAccount):
         self.account = account
 
-    async def sign_tx(self, tx: EncodedTx) -> TxEthSignature:
+    def sign_tx(self, tx: EncodedTx) -> TxEthSignature:
         message = tx.human_readable_message()
-        return await self.sign(message.encode())
+        return self.sign(message.encode())
 
-    async def sign(self, message: bytes) -> TxEthSignature:
+    def sign(self, message: bytes) -> TxEthSignature:
         signature = self.account.sign_message(encode_defunct(message))
         return TxEthSignature(signature=signature.signature, type=SignatureType.ethereum_signature)
 

--- a/zksync_sdk/wallet.py
+++ b/zksync_sdk/wallet.py
@@ -101,7 +101,7 @@ class Wallet:
             eth_auth_data=eth_auth_data
         )
 
-        eth_signature = await self.eth_signer.sign(change_pub_key.get_eth_tx_bytes())
+        eth_signature = self.eth_signer.sign(change_pub_key.get_eth_tx_bytes())
         eth_auth_data = change_pub_key.get_auth_data(eth_signature.signature)
 
         change_pub_key.eth_auth_data = eth_auth_data
@@ -139,7 +139,7 @@ class Wallet:
                                  valid_from=valid_from,
                                  valid_until=valid_until,
                                  token=token)
-        eth_signature = await self.eth_signer.sign_tx(forced_exit)
+        eth_signature = self.eth_signer.sign_tx(forced_exit)
         zk_signature = self.zk_signer.sign_tx(forced_exit)
         forced_exit.signature = zk_signature
 
@@ -166,7 +166,7 @@ class Wallet:
                             valid_from=valid_from,
                             valid_until=valid_until,
                             token=token)
-        eth_signature = await self.eth_signer.sign_tx(transfer)
+        eth_signature = self.eth_signer.sign_tx(transfer)
         zk_signature = self.zk_signer.sign_tx(transfer)
         transfer.signature = zk_signature
         return transfer, eth_signature
@@ -198,7 +198,7 @@ class Wallet:
                             valid_from=valid_from,
                             valid_until=valid_until,
                             token=token)
-        eth_signature = await self.eth_signer.sign_tx(withdraw)
+        eth_signature = self.eth_signer.sign_tx(withdraw)
         zk_signature = self.zk_signer.sign_tx(withdraw)
         withdraw.signature = zk_signature
         return withdraw, eth_signature


### PR DESCRIPTION
These interface being async doesn't seem to achieve anything, but increases API complexity, so I'd suggest making it synchronous.

It all boils down to `EthereumSignerWeb3.sign` which is an `async def` function but doesnt `await` anywhere.

This is also consistent with `ZkSyncSigner` where the sign function is synchronous.