### PR TITLE
Introduce mypy type checking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,12 @@
 SHELL := /bin/bash
 
-.PHONY: test test37 test38 test39 mypy coverage
+.PHONY: test test38 test39 mypy coverage
 
 TOX := docker-compose run --rm app tox
 
 test:
 	$(TOX)
 
-
-test37:
-	$(TOX) -e py37
 
 test38:
 	$(TOX) -e py38

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,7 @@ install_requires =
 	web3 >= 5.16
 	httpx >= 0.16
 	pydantic >= 1.7
-
+python_requires = >=3.8
 setup_requires =
 	setuptools_scm>=3.5.0
 
@@ -36,8 +36,33 @@ zksync_sdk.contract_abi =
 [tox:tox]
 envlist = py{38,39},mypy
 
-[testenv]
+[testenv:py{38,39}]
 deps = coverage
-extras = test
 setenv = ZK_SYNC_LIBRARY_PATH=/lib/zks-crypto-linux-x64.so
 commands = coverage run -m unittest
+
+[testenv:mypy]
+extras = test
+commands = mypy .
+
+[mypy]
+show_error_codes = True
+
+# TODO: These `ignore_errors` exist to gradually introduce mypy type checking.
+#       Fix the errors and remove these lines.
+[mypy-zksync_sdk.wallet.*]
+ignore_errors = True
+[mypy-zksync_sdk.contract_utils.*]
+ignore_errors = True
+[mypy-zksync_sdk.transport.http.*]
+ignore_errors = True
+[mypy-zksync_sdk.lib.*]
+ignore_errors = True
+[mypy-zksync_sdk.types.transactions.*]
+ignore_errors = True
+
+[mypy-setuptools.*]
+ignore_missing_imports = True
+
+[mypy-eth_account.*]
+ignore_missing_imports = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -56,8 +56,6 @@ ignore_errors = True
 ignore_errors = True
 [mypy-zksync_sdk.transport.http.*]
 ignore_errors = True
-[mypy-zksync_sdk.lib.*]
-ignore_errors = True
 [mypy-zksync_sdk.types.transactions.*]
 ignore_errors = True
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,8 +54,6 @@ show_error_codes = True
 ignore_errors = True
 [mypy-zksync_sdk.contract_utils.*]
 ignore_errors = True
-[mypy-zksync_sdk.transport.http.*]
-ignore_errors = True
 
 [mypy-setuptools.*]
 ignore_missing_imports = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,10 +48,6 @@ commands = mypy .
 [mypy]
 show_error_codes = True
 
-# TODO: Fix the errors in `zksync_sdk/wallet.py` and remove these lines.
-[mypy-zksync_sdk.wallet.*]
-ignore_errors = True
-
 [mypy-setuptools.*]
 ignore_missing_imports = True
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -56,8 +56,6 @@ ignore_errors = True
 ignore_errors = True
 [mypy-zksync_sdk.transport.http.*]
 ignore_errors = True
-[mypy-zksync_sdk.types.transactions.*]
-ignore_errors = True
 
 [mypy-setuptools.*]
 ignore_missing_imports = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,11 +48,8 @@ commands = mypy .
 [mypy]
 show_error_codes = True
 
-# TODO: These `ignore_errors` exist to gradually introduce mypy type checking.
-#       Fix the errors and remove these lines.
+# TODO: Fix the errors in `zksync_sdk/wallet.py` and remove these lines.
 [mypy-zksync_sdk.wallet.*]
-ignore_errors = True
-[mypy-zksync_sdk.contract_utils.*]
 ignore_errors = True
 
 [mypy-setuptools.*]

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,6 +47,7 @@ commands = mypy .
 
 [mypy]
 show_error_codes = True
+no_implicit_optional = True
 
 [mypy-setuptools.*]
 ignore_missing_imports = True

--- a/tests/test_wallet.py
+++ b/tests/test_wallet.py
@@ -62,7 +62,7 @@ class TestWallet(IsolatedAsyncioTestCase):
     async def test_change_pubkey(self):
         trans = await self.wallet.set_signing_key("ETH", eth_auth_data=ChangePubKeyEcdsa())
         try:
-            status = await trans.await_committed()
+            status = await trans.await_committed(attempts=1000, attempts_timeout=1000)
             self.assertEqual(status, TransactionStatus.COMMITTED)
         except Exception as ex:
             assert False, str(ex)

--- a/zksync_sdk/contract_utils.py
+++ b/zksync_sdk/contract_utils.py
@@ -1,10 +1,6 @@
+import importlib.resources as pkg_resources
 import json
 
-try:
-    import importlib.resources as pkg_resources
-except ImportError:
-    # Try backported to PY<37 `importlib_resources`.
-    import importlib_resources as pkg_resources
 from . import contract_abi
 
 zksync_abi_cache = None

--- a/zksync_sdk/ethereum_provider.py
+++ b/zksync_sdk/ethereum_provider.py
@@ -13,7 +13,7 @@ class EthereumProvider:
         self.web3 = web3
         self.zksync = zksync
 
-    async def approve_deposit(self, token: Token, limit: Decimal = None):
+    async def approve_deposit(self, token: Token, limit: Decimal):
         contract = ERC20Contract(self.web3, self.zksync.contract_address, token.address,
                                  self.zksync.account)
         return contract.approve_deposit(token.from_decimal(limit))

--- a/zksync_sdk/ethereum_provider.py
+++ b/zksync_sdk/ethereum_provider.py
@@ -1,4 +1,5 @@
 from decimal import Decimal
+from typing import Optional
 
 from web3 import Web3
 
@@ -30,7 +31,7 @@ class EthereumProvider:
     async def set_auth_pubkey_hash(self, pubkey_hash: bytes, nonce: int):
         return self.zksync.set_auth_pub_key_hash(pubkey_hash, nonce)
 
-    async def is_deposit_approved(self, token: Token, threshold: int = None) -> bool:
+    async def is_deposit_approved(self, token: Token, threshold: int) -> bool:
         contract = ERC20Contract(self.web3, self.zksync.contract_address, token.address,
                                  self.zksync.account)
         return contract.is_deposit_approved(threshold)

--- a/zksync_sdk/lib.py
+++ b/zksync_sdk/lib.py
@@ -36,7 +36,7 @@ class ZkSyncLibrary:
 
     def __init__(self, library_path: str = None):
         if library_path is None:
-            library_path = os.getenv("ZK_SYNC_LIBRARY_PATH")
+            library_path = os.environ["ZK_SYNC_LIBRARY_PATH"]
         self.lib = cdll.LoadLibrary(library_path)
 
     def private_key_from_seed(self, seed: bytes):
@@ -54,15 +54,15 @@ class ZkSyncLibrary:
     def get_pubkey_hash(self, public_key: bytes):
         assert len(public_key) == PUBLIC_KEY_LEN
         public_key_hash = ctypes.pointer(ZksPubkeyHash())
-        public_key = ctypes.pointer(
+        public_key_ptr = ctypes.pointer(
             ZksPackedPublicKey(data=(c_ubyte * PUBLIC_KEY_LEN)(*public_key)))
-        self.lib.zks_crypto_public_key_to_pubkey_hash(public_key, public_key_hash)
+        self.lib.zks_crypto_public_key_to_pubkey_hash(public_key_ptr, public_key_hash)
         return bytes(public_key_hash.contents.data)
 
     def sign(self, private_key: bytes, message: bytes):
         assert len(private_key) == PRIVATE_KEY_LEN
         signature = ctypes.pointer(ZksSignature())
-        private_key = ctypes.pointer(
+        private_key_ptr = ctypes.pointer(
             ZksPrivateKey(data=(c_ubyte * PRIVATE_KEY_LEN)(*private_key)))
-        self.lib.zks_crypto_sign_musig(private_key, message, len(message), signature)
+        self.lib.zks_crypto_sign_musig(private_key_ptr, message, len(message), signature)
         return bytes(signature.contents.data)

--- a/zksync_sdk/lib.py
+++ b/zksync_sdk/lib.py
@@ -1,6 +1,7 @@
 import ctypes
 from ctypes import (Structure, c_ubyte, cdll)
 import os
+from typing import Optional
 
 PRIVATE_KEY_LEN = 32
 PUBLIC_KEY_LEN = 32
@@ -34,7 +35,7 @@ class ZksSignature(Structure):
 
 class ZkSyncLibrary:
 
-    def __init__(self, library_path: str = None):
+    def __init__(self, library_path: Optional[str] = None):
         if library_path is None:
             library_path = os.environ["ZK_SYNC_LIBRARY_PATH"]
         self.lib = cdll.LoadLibrary(library_path)

--- a/zksync_sdk/serializers.py
+++ b/zksync_sdk/serializers.py
@@ -202,6 +202,8 @@ def remove_address_prefix(address: str) -> str:
     if address.startswith('sync:'):
         return address[5:]
 
+    return address
+
 
 def serialize_address(address: str) -> bytes:
     address = remove_address_prefix(address)

--- a/zksync_sdk/transport/http.py
+++ b/zksync_sdk/transport/http.py
@@ -1,5 +1,5 @@
 from http.client import OK
-from typing import List
+from typing import List, Optional
 
 import httpx
 
@@ -11,7 +11,7 @@ class HttpJsonRPCTransport(JsonRPCTransport):
     def __init__(self, network: Network):
         self.network = network
 
-    async def request(self, method: str, params: List):
+    async def request(self, method: str, params: Optional[List]):
         async with httpx.AsyncClient() as client:
             response = await client.post(self.network.zksync_url,
                                          json=self.create_request(method, params))

--- a/zksync_sdk/types/responses.py
+++ b/zksync_sdk/types/responses.py
@@ -40,6 +40,7 @@ class AccountState(BaseModel):
         alias_generator = to_camel
 
     def get_nonce(self) -> int:
+        assert self.committed is not None, "`get_nonce` needs `committed` to be set"
         return self.committed.nonce
 
 

--- a/zksync_sdk/types/transactions.py
+++ b/zksync_sdk/types/transactions.py
@@ -398,7 +398,7 @@ class Order(EncodedTx):
     valid_from: int
     valid_until: int
     signature: Optional[TxSignature] = None
-    ethSignature: Optional[TxEthSignature] = None
+    eth_signature: Optional[TxEthSignature] = None
 
     def tx_type(self) -> int:
         raise NotImplementedError
@@ -449,7 +449,7 @@ class Order(EncodedTx):
             "validFrom":        self.valid_from,
             "validUntil":       self.valid_until,
             "signature":        self.signature.dict() if self.signature else None,
-            "ethSignature":     self.ethSignature.dict() if self.ethSignature else None,
+            "ethSignature":     self.eth_signature.dict() if self.eth_signature else None,
         }
 
 @dataclass

--- a/zksync_sdk/types/transactions.py
+++ b/zksync_sdk/types/transactions.py
@@ -155,9 +155,9 @@ class ChangePubKey(EncodedTx):
     nonce: int
     valid_from: int
     valid_until: int
-    eth_auth_data: Union[ChangePubKeyCREATE2, ChangePubKeyEcdsa] = None
-    eth_signature: TxEthSignature = None
-    signature: TxSignature = None
+    eth_auth_data: Union[ChangePubKeyCREATE2, ChangePubKeyEcdsa, None] = None
+    eth_signature: Optional[TxEthSignature] = None
+    signature: Optional[TxSignature] = None
 
     def human_readable_message(self) -> str:
         message = f"Set signing key: {self.new_pk_hash.replace('sync:', '').lower()}"
@@ -227,7 +227,7 @@ class Transfer(EncodedTx):
     nonce: int
     valid_from: int
     valid_until: int
-    signature: TxSignature = None
+    signature: Optional[TxSignature] = None
 
     def tx_type(self) -> int:
         return 5
@@ -277,7 +277,7 @@ class Withdraw(EncodedTx):
     valid_from: int
     valid_until: int
     token: Token
-    signature: TxSignature = None
+    signature: Optional[TxSignature] = None
 
     def tx_type(self) -> int:
         return 3
@@ -325,7 +325,7 @@ class ForcedExit(EncodedTx):
     nonce: int
     valid_from: int
     valid_until: int
-    signature: TxSignature = None
+    signature: Optional[TxSignature] = None
 
     def tx_type(self) -> int:
         return 8

--- a/zksync_sdk/types/transactions.py
+++ b/zksync_sdk/types/transactions.py
@@ -115,7 +115,7 @@ class Tokens(BaseModel):
         else:
             return None
 
-    def find(self, token: TokenLike) -> Token:
+    def find(self, token: TokenLike) -> Optional[Token]:
         result = None
         if isinstance(token, int):
             result = self.find_by_id(token)

--- a/zksync_sdk/wallet.py
+++ b/zksync_sdk/wallet.py
@@ -103,7 +103,7 @@ class Wallet:
             fee_token: Token,
             eth_auth_data: Union[ChangePubKeyCREATE2, ChangePubKeyEcdsa, None],
             fee: int,
-            nonce: int = None,
+            nonce: Optional[int] = None,
             valid_from=DEFAULT_VALID_FROM,
             valid_until=DEFAULT_VALID_UNTIL):
         if nonce is None:
@@ -132,7 +132,7 @@ class Wallet:
 
         return change_pub_key, eth_signature
 
-    async def forced_exit(self, target: str, token: TokenLike, fee: Decimal = None,
+    async def forced_exit(self, target: str, token: TokenLike, fee: Optional[Decimal] = None,
                           valid_from=DEFAULT_VALID_FROM, valid_until=DEFAULT_VALID_UNTIL) -> Transaction:
         nonce = await self.zk_provider.get_account_nonce(self.address())
         token_obj = await self.resolve_token(token)
@@ -142,7 +142,7 @@ class Wallet:
         else:
             fee_int = token_obj.from_decimal(fee)
 
-        transfer, eth_signature = await self.build_forced_exit(target, token, fee_int, nonce,
+        transfer, eth_signature = await self.build_forced_exit(target, token_obj, fee_int, nonce,
                                                                valid_from, valid_until)
 
         return await self.send_signed_transaction(transfer, eth_signature)
@@ -154,7 +154,7 @@ class Wallet:
             target: str,
             token: Token,
             fee: int,
-            nonce: int = None,
+            nonce: Optional[int] = None,
             valid_from=DEFAULT_VALID_FROM,
             valid_until=DEFAULT_VALID_UNTIL) -> Tuple[ForcedExit, TxEthSignature]:
         if nonce is None:
@@ -174,7 +174,7 @@ class Wallet:
 
         return forced_exit, eth_signature
 
-    async def mint_nft(self, content_hash: str, recipient: str,token: TokenLike, fee: Decimal = None) -> Transaction:
+    async def mint_nft(self, content_hash: str, recipient: str,token: TokenLike, fee: Optional[Decimal] = None) -> Transaction:
         token_obj = await self.resolve_token(token)
 
         nonce = await self.zk_provider.get_account_nonce(self.address())
@@ -300,7 +300,7 @@ class Wallet:
         return transfer, eth_signature
 
     async def transfer(self, to: str, amount: Decimal, token: TokenLike,
-                       fee: Decimal = None,
+                       fee: Optional[Decimal] = None,
                        valid_from=DEFAULT_VALID_FROM, valid_until=DEFAULT_VALID_UNTIL) -> Transaction:
         nonce = await self.zk_provider.get_account_nonce(self.address())
         token_obj = await self.resolve_token(token)

--- a/zksync_sdk/wallet.py
+++ b/zksync_sdk/wallet.py
@@ -371,7 +371,7 @@ class Wallet:
                       valid_from=valid_from,
                       valid_until=valid_until)
 
-        order.ethSignature = self.eth_signer.sign_tx(order)
+        order.eth_signature = self.eth_signer.sign_tx(order)
         order.signature = self.zk_signer.sign_tx(order)
 
         return order

--- a/zksync_sdk/wallet.py
+++ b/zksync_sdk/wallet.py
@@ -79,7 +79,8 @@ class Wallet:
                 fee_obj = await self.zk_provider.get_transaction_fee(FeeTxType.change_pub_key_onchain,
                                                                  self.address(),
                                                                  fee_token)
-            else:  # eth_auth_type == ChangePubKeyTypes.create2
+            else:
+                assert eth_auth_type == ChangePubKeyTypes.create2, "invalid eth_auth_type"
                 fee_obj = await self.zk_provider.get_transaction_fee(FeeTxType.change_pub_key_create2,
                                                                  self.address(),
                                                                  fee_token)

--- a/zksync_sdk/wallet.py
+++ b/zksync_sdk/wallet.py
@@ -213,12 +213,12 @@ class Wallet:
 
     async def get_balance(self, token: TokenLike, type: str):
         account_state = await self.get_account_state()
-        token = await self.resolve_token(token)
+        token_obj = await self.resolve_token(token)
 
         if type == "committed":
-            token_balance = account_state.committed.balances.get(token.symbol)
+            token_balance = account_state.committed.balances.get(token_obj.symbol)
         else:
-            token_balance = account_state.verified.balances.get(token.symbol)
+            token_balance = account_state.verified.balances.get(token_obj.symbol)
         if token_balance is None:
             token_balance = 0
         return token_balance

--- a/zksync_sdk/wallet.py
+++ b/zksync_sdk/wallet.py
@@ -43,8 +43,8 @@ class Wallet:
         return await self.zk_provider.submit_txs_batch(transactions, signatures)
 
     async def set_signing_key(self, fee_token: TokenLike, *,
-                              eth_auth_data: Union[ChangePubKeyCREATE2, ChangePubKeyEcdsa] = None,
-                              fee: Decimal = None, nonce: int = None,
+                              eth_auth_data: Union[ChangePubKeyCREATE2, ChangePubKeyEcdsa, None] = None,
+                              fee: Optional[Decimal] = None, nonce: Optional[int] = None,
                               valid_from=DEFAULT_VALID_FROM, valid_until=DEFAULT_VALID_UNTIL):
         change_pub_key, eth_signature = await self.build_change_pub_key(fee_token,
                                                                         eth_auth_data=eth_auth_data,
@@ -56,8 +56,8 @@ class Wallet:
 
     async def build_change_pub_key(
         self, fee_token: TokenLike, *,
-        fee: Decimal = None, nonce: int = None,
-        eth_auth_data: Union[ChangePubKeyCREATE2, ChangePubKeyEcdsa] = None,
+        fee: Optional[Decimal] = None, nonce: Optional[int] = None,
+        eth_auth_data: Union[ChangePubKeyCREATE2, ChangePubKeyEcdsa, None] = None,
         valid_from=DEFAULT_VALID_FROM, valid_until=DEFAULT_VALID_UNTIL
     ):
         account_id, new_nonce = await self.zk_provider.get_account_nonce(self.address())
@@ -110,7 +110,7 @@ class Wallet:
 
         return change_pub_key, eth_signature
 
-    async def forced_exit(self, target: str, token: TokenLike, fee: Decimal = None,
+    async def forced_exit(self, target: str, token: TokenLike, fee: Optional[Decimal] = None,
                           valid_from=DEFAULT_VALID_FROM, valid_until=DEFAULT_VALID_UNTIL) -> str:
         transfer, eth_signature = await self.build_forced_exit(target, token, fee,
                                                                valid_from, valid_until)
@@ -121,7 +121,7 @@ class Wallet:
         self,
         target: str,
         token: TokenLike,
-        fee: Decimal = None,
+        fee: Optional[Decimal] = None,
         valid_from=DEFAULT_VALID_FROM,
         valid_until=DEFAULT_VALID_UNTIL
     ) -> Tuple[ForcedExit, TxEthSignature]:
@@ -149,7 +149,7 @@ class Wallet:
         return self.eth_signer.address()
 
     async def build_transfer(self, to: str, amount: Decimal, token: TokenLike,
-                             fee: Decimal = None,
+                             fee: Optional[Decimal] = None,
                              valid_from=DEFAULT_VALID_FROM,
                              valid_until=DEFAULT_VALID_UNTIL) -> Tuple[Transfer, TxEthSignature]:
         account_id, nonce = await self.zk_provider.get_account_nonce(self.address())
@@ -172,7 +172,7 @@ class Wallet:
         return transfer, eth_signature
 
     async def transfer(self, to: str, amount: Decimal, token: TokenLike,
-                       fee: Decimal = None,
+                       fee: Optional[Decimal] = None,
                        valid_from=DEFAULT_VALID_FROM, valid_until=DEFAULT_VALID_UNTIL) -> str:
         transfer, eth_signature = await self.build_transfer(to, amount, token, fee,
                                                             valid_from, valid_until)
@@ -180,7 +180,7 @@ class Wallet:
         return await self.send_signed_transaction(transfer, eth_signature)
 
     async def build_withdraw(self, eth_address: str, amount: Decimal, token: TokenLike,
-                             fee: Decimal = None, fast: bool = False,
+                             fee: Optional[Decimal] = None, fast: bool = False,
                              valid_from=DEFAULT_VALID_FROM,
                              valid_until=DEFAULT_VALID_UNTIL) -> Tuple[Withdraw, TxEthSignature]:
         account_id, nonce = await self.zk_provider.get_account_nonce(self.address())
@@ -204,7 +204,7 @@ class Wallet:
         return withdraw, eth_signature
 
     async def withdraw(self, eth_address: str, amount: Decimal, token: TokenLike,
-                       fee: Decimal = None, fast: bool = False,
+                       fee: Optional[Decimal] = None, fast: bool = False,
                        valid_from=DEFAULT_VALID_FROM, valid_until=DEFAULT_VALID_UNTIL) -> str:
 
         withdraw, eth_signature = await self.build_withdraw(eth_address, amount, token, fee, fast,

--- a/zksync_sdk/zksync.py
+++ b/zksync_sdk/zksync.py
@@ -11,7 +11,7 @@ class Contract:
     def __init__(self, contract_address: str, web3: Web3, account: BaseAccount, abi):
         self.contract_address = contract_address
         self.web3 = web3
-        self.contract = self.web3.eth.contract(self.contract_address, abi=abi)  # type: ignore
+        self.contract = self.web3.eth.contract(self.contract_address, abi=abi)  # type: ignore[call-overload]
         self.account = account
 
     def _call_method(self, method_name, *args, amount=None, **kwargs):

--- a/zksync_sdk/zksync.py
+++ b/zksync_sdk/zksync.py
@@ -11,7 +11,7 @@ class Contract:
     def __init__(self, contract_address: str, web3: Web3, account: BaseAccount, abi):
         self.contract_address = contract_address
         self.web3 = web3
-        self.contract = self.web3.eth.contract(self.contract_address, abi=abi)
+        self.contract = self.web3.eth.contract(self.contract_address, abi=abi)  # type: ignore
         self.account = account
 
     def _call_method(self, method_name, *args, amount=None, **kwargs):

--- a/zksync_sdk/zksync_provider/v01.py
+++ b/zksync_sdk/zksync_provider/v01.py
@@ -57,6 +57,7 @@ class ZkSyncProviderV01(ZkSyncProviderInterface):
 
     async def get_account_nonce(self, address: str) -> Tuple[int, int]:
         state = await self.get_state(address)
+        assert state.id is not None, "AccountState must have ID"
         return state.id, state.get_nonce()
 
     async def get_tx_receipt(self, address: str) -> TransactionDetails:

--- a/zksync_sdk/zksync_signer.py
+++ b/zksync_sdk/zksync_signer.py
@@ -9,8 +9,8 @@ def derive_private_key(library: ZkSyncLibrary, message: str, account: BaseAccoun
                        chain_id: ChainId):
     if chain_id != ChainId.MAINNET:
         message = f"{message}\nChain ID: {chain_id}."
-    message = encode_defunct(message.encode())
-    signature = account.sign_message(message)
+    signable_message = encode_defunct(message.encode())
+    signature = account.sign_message(signable_message)
     private_key = library.private_key_from_seed(signature.signature)
     return private_key
 


### PR DESCRIPTION
Closes https://github.com/zksync-sdk/zksync-python/issues/13

Fixes the `make mypy` and `tox -e mypy` invocations, which used to run unittests, now run mypy.
Fixes all mypy errors.